### PR TITLE
Correct spelling errors in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ A new Superchain Target can be added by creating a new superchain config directo
 with a `superchain.yaml` config file.
 
 > **Note**
-> This is an infrequent operation and unecessary if you are just looking to add a chain to an existing superchain.
+> This is an infrequent operation and unnecessary if you are just looking to add a chain to an existing superchain.
 
 Here's an example:
 
@@ -56,7 +56,7 @@ Superchain-wide configuration, like the `ProtocolVersions` contract address, sho
 
 ## `superchain` Go Module
 
-Per chain and supechain-wide configs and extra data are embedded into the `superchain` go module, which can be imported like so:
+Per chain and superchain-wide configs and extra data are embedded into the `superchain` go module, which can be imported like so:
 
 ```
 go get github.com/ethereum-optimism/superchain-registry/superchain@latest
@@ -106,7 +106,7 @@ the following privilege grants and role designations:
       from. TODO(issues/37): add checks for the `ResourceMetering`
       contract.
 3. Optimism privileged operational roles:
-   1. Guardians. This is the role that can pause withdraws in the
+   1. Guardians. This is the role that can pause withdrawals in the
       Optimism protocol.
       1. After the Fault Proofs upgrade, the `Guardian` can also blacklist dispute games and change the respected game type
          in the `OptimismPortal`.


### PR DESCRIPTION
1. **"unecessary"** → **"unnecessary"**  
   - Correct spelling of the word to align with standard English usage.

2. **"supechain"** → **"superchain"**  
   - Corrected a misspelling to accurately reflect the intended term.

3. **"withdraws"** → **"withdrawals"**  
   - Adjusted the term for grammatical correctness and proper context.